### PR TITLE
Check local storage size and remove old data (#84)

### DIFF
--- a/client/src/services/Storage.ts
+++ b/client/src/services/Storage.ts
@@ -17,6 +17,8 @@ export class StorageItem {
   }
 }
 
+export type StorageSizeInfo = { spaceUsed: number; spaceLeft: number };
+
 export class LocalStorage {
   supported: boolean;
 
@@ -27,6 +29,9 @@ export class LocalStorage {
   }
 
   add(key: string, item: string) {
+    if (this.getStorageSizeInfo().spaceLeft < 0.5) {
+      this.clear();
+    }
     localStorage.setItem(key, item);
   }
 
@@ -78,5 +83,20 @@ export class LocalStorage {
 
   clear() {
     localStorage.clear();
+  }
+
+  getStorageSizeInfo(): StorageSizeInfo {
+    let lsTotal = 0,
+      itemLen,
+      item;
+    for (item in localStorage) {
+      if (!localStorage.hasOwnProperty(item)) continue;
+      itemLen = (localStorage[item].length + item.length) * 2;
+      lsTotal += itemLen;
+    }
+    return {
+      spaceUsed: 5120 / 1024 - lsTotal / 1024,
+      spaceLeft: lsTotal / 1024,
+    };
   }
 }


### PR DESCRIPTION
This is for issue #84 .

Adds method to check local storage size. When adding data to the storage, if the available space left is less than an arbitrarily (currently hardcoded) amount, calls `clear()` to free space. I used this approach because it is not possible (as far as I know) to check the age of items in storage unless we track it ourselves, which would likely cause us to use significantly more storage in itself.