### PR TITLE
Fix drag and drop not working for image upload

### DIFF
--- a/client/src/components/base/ImageInput.tsx
+++ b/client/src/components/base/ImageInput.tsx
@@ -58,11 +58,10 @@ export default function ImageInput({
   };
 
   const getFiles = (e: any) => {
-    if (e.currentTarget) {
-      return e.currentTarget?.files;
+    if (e.dataTransfer) {
+      return e.dataTransfer.files;
     }
-
-    return e.dataTransfer.files;
+    return e.currentTarget?.files;
   };
 
   const saveImage = (


### PR DESCRIPTION
The `eventTarget` is always present, switched to checking the `dataTransfer` property which exists only on drag&drop.

See code.